### PR TITLE
chore: adopt nox + warden

### DIFF
--- a/.github/workflows/nox-remediate.yml
+++ b/.github/workflows/nox-remediate.yml
@@ -1,0 +1,12 @@
+name: Nox Remediate
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch: {}
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  remediate:
+    uses: felixgeelhaar/.github/.github/workflows/nox-remediate.yml@main
+    secrets: inherit

--- a/.github/workflows/nox-scan.yml
+++ b/.github/workflows/nox-scan.yml
@@ -1,0 +1,110 @@
+# Standalone nox security scan — lifts the `security` job of the reusable
+# felixgeelhaar/.github go-ci.yml, kept separate so it never touches the
+# existing ci.yml required-check job names (test / lint).
+#
+# Pinned + sha256-verified nox 1.7.1, cosign for signed-plugin trust,
+# source-to-sink taint SAST, SARIF -> GitHub code scanning, and a
+# self-adjusting gate: report-only until a nox baseline exists (a baseline is
+# committed at .nox/baseline.json, so this gate enforces net-new critical/high
+# and stays green while known findings remain waived).
+name: Nox Security Scan
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'site/**'
+      - 'LICENSE'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'site/**'
+      - 'LICENSE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security:
+    name: Security (nox)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write   # nox annotate
+    env:
+      NOX_VERSION: "1.7.1"
+      NOX_SHA256: "3106ab3ce7197f43a45fc1128ea27112686421e8ec3eac9be356d4ca42ab4c89"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install nox (pinned + sha256-verified binary)
+        run: |
+          curl -sL -o nox.tar.gz \
+            "https://github.com/nox-hq/nox/releases/download/v${NOX_VERSION}/nox_${NOX_VERSION}_linux_amd64.tar.gz"
+          echo "${NOX_SHA256}  nox.tar.gz" | sha256sum -c -
+          tar xzf nox.tar.gz && sudo mv nox /usr/local/bin/ && nox version
+
+      - name: Install cosign
+        # nox verifies plugin signatures by shelling out to cosign. Without it,
+        # signed plugins can't be promoted past "unverified" and install is
+        # blocked under the default community-trust policy.
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install taint-analysis plugin
+        # nox owns code-level SAST: source-to-sink taint (SSRF, injection, path
+        # traversal). The plugin is cosign-signed; with cosign present nox
+        # promotes it to community trust and installs it (no bypass).
+        run: nox plugin install nox/taint-analysis
+
+      - name: Scan
+        run: nox scan . -format json,sarif -output nox-results || true
+
+      - name: Upload SARIF to code scanning
+        if: always() && hashFiles('nox-results/results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: nox-results/results.sarif
+
+      - name: Annotate PR
+        if: github.event_name == 'pull_request' && hashFiles('nox-results/findings.json') != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: nox annotate -input nox-results/findings.json || true
+
+      - name: Gate on net-new critical/high findings
+        # Self-adjusting: report-only until the repo commits a nox baseline,
+        # then gates net-new critical/high. Adopting the workflow never breaks a
+        # red build on day one.
+        if: always() && hashFiles('nox-results/findings.json') != ''
+        run: |
+          f=nox-results/findings.json
+          baselined=$(jq '[.findings[]? | select(.Status=="baselined")] | length' "$f" 2>/dev/null || echo 0)
+          new=$(jq '[.findings[]? | select((.Severity=="critical" or .Severity=="high") and (.Status!="baselined"))] | length' "$f" 2>/dev/null || echo 0)
+          echo "net-new critical/high: $new (baselined findings: $baselined)"
+          if [ "$baselined" -eq 0 ]; then
+            echo "::notice::No nox baseline established — security gate is report-only. Run 'nox baseline add' and commit .nox/ to enforce net-new critical/high."
+            exit 0
+          fi
+          if [ "$new" -gt 0 ]; then
+            echo "::error::Net-new critical/high findings. Run 'nox baseline add' or remediate."
+            jq '.findings[] | select((.Severity=="critical" or .Severity=="high") and (.Status!="baselined")) | {severity:.Severity, rule:.RuleID, file:.Location.FilePath, line:.Location.StartLine}' "$f"
+            exit 1
+          fi
+
+      - name: Upload nox artifacts
+        if: always() && hashFiles('nox-results/**') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nox-results
+          path: nox-results/
+          retention-days: 7

--- a/.nox.yaml
+++ b/.nox.yaml
@@ -1,0 +1,42 @@
+# nox configuration — the security/dependency gate that replaces dependabot.
+# Schema reference: https://github.com/nox-hq/nox
+#
+# Only GENERATED, VENDORED, or PROSE/DATA artifacts are excluded here. All
+# first-party Go source — including *_test.go — is scanned. Any remaining
+# first-party critical/high findings are accepted as documented false positives
+# via .nox/baseline.json, never by blinding whole source directories.
+
+scan:
+  exclude:
+    # Go module checksum database — SHA-256 module digests read as high-entropy
+    # secrets/API keys to the entropy detector. Real dependency CVEs are
+    # surfaced via OSV lookups on go.mod, not go.sum text.
+    # Classification: False Positive (module digests). Last reviewed: 2026-07-11
+    - go.sum
+    - "**/go.sum"
+    # npm lockfile for the docs website (site/, Astro Starlight): integrity
+    # hashes look like API keys to the entropy detector. Dependency CVEs are
+    # surfaced via OSV directly, not the lockfile text.
+    # Classification: False Positive (integrity hashes). Last reviewed: 2026-07-11
+    - "**/package-lock.json"
+    # Markdown is prose — README, docs/, CHANGELOG, and the site/ content. The
+    # secret/PII entropy rules fire on ordinary documentation. High-confidence
+    # real secret patterns are still caught in code, not prose.
+    # Classification: False Positive (prose). Last reviewed: 2026-07-11
+    - README.md
+    - "*.md"
+    - "**/*.md"
+    # Test fixtures — golden/data files under testdata/ are inert sample data,
+    # not executable code, and trip secret/data rules.
+    # Classification: False Positive (test fixtures). Last reviewed: 2026-07-11
+    - testdata/
+    # Generated protobuf stubs — machine-generated, not hand-authored source.
+    # Classification: Acceptable Pattern (generated code). Last reviewed: 2026-07-11
+    - "*.pb.go"
+    # nox's own baseline/cache and report output — finding fingerprints are
+    # SHA-256 hex that re-trip the secret detector. Never scan the scanner.
+    # Classification: Acceptable Pattern (scanner state). Last reviewed: 2026-07-11
+    - .nox/
+    - findings.json
+    - nox-results/
+    - "*.sarif"

--- a/.nox/baseline.json
+++ b/.nox/baseline.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "1.0.0",
+  "entries": [
+    {
+      "fingerprint": "8842db314bb3e09388f1a86001c225974121e2d637dc4d45d5b685709bf49f5c",
+      "rule_id": "DATA-002",
+      "file_path": "internal/infrastructure/policy/redactor_test.go",
+      "severity": "high",
+      "reason": "Adoption baseline: 3 documented FPs (SSN test fixture redactor_test.go, SSN docs example AgentPolicies.astro, id-token:write permissions misread as secret in pages.yml) + 3 pre-existing IAC-013 unpinned-action findings in existing ci/pages/release workflows accepted for this nox-adoption PR (tracked for SHA-pin follow-up).",
+      "owner": "felixgeelhaar",
+      "created_at": "2026-07-11T11:17:42.844526Z"
+    },
+    {
+      "fingerprint": "63ff8e1da3700a262e285e4c65700c16758a81ced9747e0d95377bb396dc671d",
+      "rule_id": "DATA-002",
+      "file_path": "site/src/components/AgentPolicies.astro",
+      "severity": "high",
+      "reason": "Adoption baseline: 3 documented FPs (SSN test fixture redactor_test.go, SSN docs example AgentPolicies.astro, id-token:write permissions misread as secret in pages.yml) + 3 pre-existing IAC-013 unpinned-action findings in existing ci/pages/release workflows accepted for this nox-adoption PR (tracked for SHA-pin follow-up).",
+      "owner": "felixgeelhaar",
+      "created_at": "2026-07-11T11:17:42.844526Z"
+    },
+    {
+      "fingerprint": "8533ee1ccd42d189724a3bc43cda84b9c188265c6f1fd8ac638345deaac580bc",
+      "rule_id": "IAC-013",
+      "file_path": ".github/workflows/ci.yml",
+      "severity": "high",
+      "reason": "Adoption baseline: 3 documented FPs (SSN test fixture redactor_test.go, SSN docs example AgentPolicies.astro, id-token:write permissions misread as secret in pages.yml) + 3 pre-existing IAC-013 unpinned-action findings in existing ci/pages/release workflows accepted for this nox-adoption PR (tracked for SHA-pin follow-up).",
+      "owner": "felixgeelhaar",
+      "created_at": "2026-07-11T11:17:42.844526Z"
+    },
+    {
+      "fingerprint": "213dc33cc7f95aed46469b3035c54b5f9e846582e2de305f19b5e54b7268a394",
+      "rule_id": "IAC-013",
+      "file_path": ".github/workflows/pages.yml",
+      "severity": "high",
+      "reason": "Adoption baseline: 3 documented FPs (SSN test fixture redactor_test.go, SSN docs example AgentPolicies.astro, id-token:write permissions misread as secret in pages.yml) + 3 pre-existing IAC-013 unpinned-action findings in existing ci/pages/release workflows accepted for this nox-adoption PR (tracked for SHA-pin follow-up).",
+      "owner": "felixgeelhaar",
+      "created_at": "2026-07-11T11:17:42.844526Z"
+    },
+    {
+      "fingerprint": "cb32d96da520c9c12b3acff7ac9cf69b5e3d6a8e22f85b7badf23361282bcc6b",
+      "rule_id": "IAC-013",
+      "file_path": ".github/workflows/release.yml",
+      "severity": "high",
+      "reason": "Adoption baseline: 3 documented FPs (SSN test fixture redactor_test.go, SSN docs example AgentPolicies.astro, id-token:write permissions misread as secret in pages.yml) + 3 pre-existing IAC-013 unpinned-action findings in existing ci/pages/release workflows accepted for this nox-adoption PR (tracked for SHA-pin follow-up).",
+      "owner": "felixgeelhaar",
+      "created_at": "2026-07-11T11:17:42.844526Z"
+    },
+    {
+      "fingerprint": "22df83a7b52ce4b665c7463555bd49f17ae2cfdf0320c6447e4ccf97c8aa3773",
+      "rule_id": "IAC-351",
+      "file_path": ".github/workflows/pages.yml",
+      "severity": "critical",
+      "reason": "Adoption baseline: 3 documented FPs (SSN test fixture redactor_test.go, SSN docs example AgentPolicies.astro, id-token:write permissions misread as secret in pages.yml) + 3 pre-existing IAC-013 unpinned-action findings in existing ci/pages/release workflows accepted for this nox-adoption PR (tracked for SHA-pin follow-up).",
+      "owner": "felixgeelhaar",
+      "created_at": "2026-07-11T11:17:42.844526Z"
+    }
+  ]
+}

--- a/.warden.yaml
+++ b/.warden.yaml
@@ -1,0 +1,39 @@
+# warden — local git gate for acai (Go). Sole hook manager; the persistent
+# artifact is this file. pre-commit stays fast (format + vet); pre-push runs the
+# checks CI enforces (race tests, build) so nothing leaves the machine that CI
+# would reject. warden's native hooks live in .git/hooks and auto-fetch the
+# binary if missing, so a fresh clone is gated with no toolchain beyond the Go
+# SDK the repo already requires.
+#
+# NOTE: this repo ships no .golangci.yml, so golangci-lint is intentionally NOT
+# a warden command here (CI runs it with default rules; add it back once a
+# .golangci.yml is committed). Tests/build run with CGO on the dev's machine
+# (mattn/go-sqlite3), matching CI's CGO_ENABLED=1.
+extends: ''
+agent: auto
+hooks:
+  pre_commit: true
+  pre_push: true
+commands:
+  # gofmt -l lists mis-formatted files; warden treats non-empty output as a
+  # failure, so this CHECKS formatting (run `gofmt -w .` to fix).
+  gofmt: gofmt -l .
+  govet: go vet ./...
+  gotest: go test -race ./...
+  gobuild: go build ./...
+steps:
+  pre_commit:
+    - gofmt
+    - govet
+  pre_push:
+    - rebase
+    - gofmt
+    - govet
+    - gotest
+    - gobuild
+risk:
+  diff_lines_high: 400
+  files_touched_high: 15
+pr:
+  enabled: false
+rules: []


### PR DESCRIPTION
Adopts **nox** (security/dependency scanning, replacing Dependabot) and **warden** (local git-hook gate), mirroring `felixgeelhaar/preflight` #128.

## What changed

- **`.github/workflows/nox-scan.yml`** — standalone security scan lifted from the central `felixgeelhaar/.github` `go-ci.yml` `security` job. Pinned + sha256-verified **nox 1.7.1**, cosign-verified `taint-analysis` SAST, SARIF → GitHub code scanning (`nox-results/results.sarif`), and a self-adjusting gate on net-new critical/high. Triggers on push/PR to `main`. Job name **`Security (nox)`** — deliberately separate from `ci.yml` so its `test`/`lint` job names are untouched.
- **`.github/workflows/nox-remediate.yml`** — weekly (`17 6 * * 1`) + `workflow_dispatch`, calls the central reusable `felixgeelhaar/.github/.github/workflows/nox-remediate.yml@main` with `secrets: inherit`.
- **`.nox.yaml`** — scan config excluding only generated/vendored/prose/data (`go.sum`, `**/package-lock.json`, markdown, `testdata/`, `*.pb.go`, scanner state). All first-party Go source — including `*_test.go` — is scanned.
- **`.nox/baseline.json`** — 6 accepted critical/high findings so the gate is green on day one and only *net-new* critical/high break the build.
- **`.warden.yaml`** — Go gate: pre-commit (`gofmt`, `govet`), pre-push (`rebase`, `gofmt`, `govet`, `go test -race`, `go build`). `golangci-lint` is intentionally omitted because this repo ships no `.golangci.yml`.

## Baseline breakdown (6 critical/high)

**False positives (3):**
- `DATA-002` SSN pattern in `internal/infrastructure/policy/redactor_test.go` — fake SSN test fixture for the redactor.
- `DATA-002` SSN pattern in `site/src/components/AgentPolicies.astro` — example SSN in docs-site content.
- `IAC-351` "hardcoded secret" in `.github/workflows/pages.yml` — the `id-token: write` **permissions** line misread as a secret.

**Pre-existing, accepted for this PR (3):**
- `IAC-013` unpinned actions in `ci.yml`, `pages.yml`, `release.yml` (mutable tags e.g. `@v7`/`@v3`/`@v6`). Real supply-chain hardening debt in the **existing** workflows; out of scope for this adoption PR (would change unrelated CI files). **Recommended follow-up: SHA-pin these actions**, after which the baseline entries can be dropped.

## Dependabot

No `.github/dependabot.yml` or auto-merge workflow existed to remove. Automated security fixes disabled via API; the two open Dependabot PRs (#22, #23) were closed.

https://claude.ai/code/session_01XsciE5KjxtMrHimxWxBVFS