### PR TITLE
fix(ci): pin the nox taint plugin and stop a registry 404 failing the scan

### DIFF
--- a/.github/workflows/nox-scan.yml
+++ b/.github/workflows/nox-scan.yml
@@ -61,10 +61,11 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install taint-analysis plugin
+        continue-on-error: true  # plugin registry 404s are not a security failure
         # nox owns code-level SAST: source-to-sink taint (SSRF, injection, path
         # traversal). The plugin is cosign-signed; with cosign present nox
         # promotes it to community trust and installs it (no bypass).
-        run: nox plugin install nox/taint-analysis
+        run: nox plugin install nox/taint-analysis@0.7.0
 
       - name: Scan
         run: nox scan . -format json,sarif -output nox-results || true


### PR DESCRIPTION
The **Security job has been red since 2026-07-19**. `nox plugin install nox/taint-analysis` resolves `@*` against source `"official"`, which now returns HTTP 404:

```
error: resolving nox/taint-analysis@*: source "official": registry returned HTTP 404
##[error]Process completed with exit code 2
```

The install step sits **before** the scan, so a registry hiccup does not merely degrade security scanning — it disables it entirely *and* fails the job. Worst of both outcomes: no scan, and a red check that trains people to ignore it.

## Fix

Exactly what `klarlabs-studio/.github`'s shared `go-ci.yml` already does — and which passes in CI today, so this is a proven configuration rather than a guess:

```yaml
- name: Install taint-analysis plugin
  continue-on-error: true   # plugin registry 404s are not a security failure
  run: nox plugin install nox/taint-analysis@0.7.0
```

- **Pin `@0.7.0`** — the unpinned range is what 404s.
- **`continue-on-error: true`** — the plugin is an *enhancement*; the core SEC/IAC/DATA/VULN rules ship in nox itself. A registry outage should cost the taint rules, not the entire scan.

## Scope

**15 repos** carried the unpinned form. Only the shared workflow was ever fixed, back in July — every repo with its own nox job kept the broken version and has been failing for a week.

Found while checking why an unrelated goreleaser-config PR showed a red Security check. The failure **pre-dates that PR and reproduces on `main`** (roady's `Security [main]` is red with no PR involved), so it is genuinely independent.
