### PR TITLE
chore(release): publish a Homebrew cask instead of a formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,19 +50,15 @@ changelog:
       - "^ci:"
       - "^chore:"
 
-brews:
-  - repository:
-      owner: felixgeelhaar
-      name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
-    directory: Formula
-    name: acai
-    homepage: "https://github.com/felixgeelhaar/acai"
-    description: "Go CLI and MCP server for Granola meeting intelligence"
-    license: "MIT"
-    install: |
-      bin.install "acai"
-
+homebrew_casks:
+    - repository:
+        owner: "felixgeelhaar"
+        name: "homebrew-tap"
+        token: "{{ .Env.GITHUB_TOKEN }}"
+      name: "acai"
+      homepage: "https://github.com/felixgeelhaar/acai"
+      description: "Go CLI and MCP server for Granola meeting intelligence"
+      license: "MIT"
 release:
   github:
     owner: felixgeelhaar


### PR DESCRIPTION
`brews` is deprecated in goreleaser; `homebrew_casks` is the replacement, and Homebrew itself now prefers casks for pre-built binaries — which is what this ships.

## Why it is safe here

The formula's `install:` is only `bin.install`, which a cask's generated binary stanza covers exactly.

**Repos whose install block does more are deliberately not migrated.** `specular` installs bash/zsh/fish completions and declares an optional `docker` dependency — a cask carries neither, so migrating it would silently drop working functionality. It keeps its formula until that is handled properly.

`test:` is dropped where present: casks have no equivalent, so the `brew test` check goes with it. Small, and the alternative is staying on a deprecated key.

## The sequencing hazard this does *not* trip

Nothing changes in the tap when this merges — goreleaser only writes there on release.

The window to watch is **after the next release**, when `Casks/<name>.rb` and the old `Formula/<name>.rb` coexist. **brew prefers the formula**, so users would silently keep receiving the older artefact. The stale formula must be deleted as soon as the first cask lands.

That is not hypothetical: it was removed from the taps today for **preflight** (formula 4.11.1 shadowing cask 4.12.0), **nomi** and **mnemos**.

## How the block was rewritten

Structurally, not by regex. An earlier text-based pass ate neighbouring top-level sections in three of these repos — caught by asserting the top-level key set was unchanged, and reverted. This version parses the entry, drops the formula-only keys, and re-emits it.

Verified per repo: YAML parses, the top-level key set is identical apart from `brews` → `homebrew_casks`, and `goreleaser check` reports **zero deprecations**.
