### PR TITLE
chore(security): nox remediation (deps + actions)

### DIFF
--- a/.github/workflows/nox-scan.yml
+++ b/.github/workflows/nox-scan.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload SARIF to code scanning
         if: always() && hashFiles('nox-results/results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: nox-results/results.sarif
 


### PR DESCRIPTION
Automated remediation by `nox fix --actions`: OSV-vulnerable dependency upgrades plus outdated and mutable GitHub Actions pins bumped to their SHA-pinned latest release. Replaces dependabot.